### PR TITLE
Pass VarProviders list to Templater configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ return {
                 journal = {
                     template_name = "daily",
                 },
+                templater = {
+                    home = "~/Notes/meta/templates"
+                    extra_providers = {
+                      {
+                        name = "descr",
+                        func = function()
+                          local val = vim.fn.input "Enter description: "
+                          return val
+                        end,
+                      },
+                   },
+                }
+
             }
 
             vim.keymap.set("n", "<leader>nn", "<cmd>ObsNvimFollowLink<cr>")

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ return {
                     template_name = "daily",
                 },
                 templater = {
-                    home = "~/Notes/meta/templates"
+                    home = "~/Notes/meta/templates",
                     extra_providers = {
                       {
                         name = "descr",
@@ -50,7 +50,7 @@ return {
                           return val
                         end,
                       },
-                   },
+                    },
                 }
 
             }

--- a/lua/obs/templater.lua
+++ b/lua/obs/templater.lua
@@ -21,6 +21,7 @@ local File = require "obs.utils.file"
 ---@class obs.TemplaterOpts
 ---@field public include_default_providers? boolean
 ---@field public home string
+---@field public extra_providers? obs.VarProvider[]
 local TemplaterOpts = {}
 TemplaterOpts.__index = TemplaterOpts
 
@@ -29,6 +30,7 @@ function TemplaterOpts:new(opts)
     local this = setmetatable(
         vim.tbl_extend("force", {
             include_default_providers = true,
+            extra_providers = {},
         }, opts),
         self
     )
@@ -66,6 +68,12 @@ function Templater:new(opts)
         end)
     end
 
+    if opts.extra_providers then
+        for _, provider in ipairs(opts.extra_providers) do
+            templater:add_var_provider(provider.name, provider.func)
+        end
+    end
+
     return templater
 end
 
@@ -73,7 +81,7 @@ end
 function Templater:search_and_insert_template()
     local templates = self:list_templates()
     if #templates == 0 then
-        vim.notify "No templates found"
+        vim.notify ( "No templates found: " .. tostring(self._home_path) ) 
         return
     end
 
@@ -127,22 +135,21 @@ function Templater:process(opts)
         or self:_get_raw_template_content(opts.template_name)
 
     if not template then
-        error(
-            "must have template or template_name specified but was "
-                .. vim.inspect(opts)
-        )
+        error("must have template or template_name specified")
     end
 
     for _, var_provider in ipairs(self._var_providers) do
         local name = var_provider.name
-        local func = var_provider.func
-        local res = func { filename = opts.filename }
-        template = string.gsub(template, "{{" .. name .. "}}", res)
+        local tag = "{{" .. name .. "}}"
+        if string.find(template, tag, 1, true) then
+            local func = var_provider.func
+            local res = func { filename = opts.filename }
+            template = string.gsub(template, tag, res)
+        end
     end
 
     return template
 end
-
 -- performs templating using raw content and current buffer name
 ---@param template string
 ---@return string

--- a/lua/obs/templater.lua
+++ b/lua/obs/templater.lua
@@ -81,7 +81,7 @@ end
 function Templater:search_and_insert_template()
     local templates = self:list_templates()
     if #templates == 0 then
-        vim.notify ( "No templates found: " .. tostring(self._home_path) ) 
+        vim.notify "No templates found"
         return
     end
 

--- a/lua/obs/templater_spec.lua
+++ b/lua/obs/templater_spec.lua
@@ -136,4 +136,72 @@ describe("process string", function()
             "template was not overriden"
         )
     end)
+
+    --  Tests of users extra_providers
+
+    it("can be initialized with extra_providers in opts", function()
+        local templater = Templater:new {
+            home = ".",
+            extra_providers = {
+                {
+                    name = "callme",
+                    func = function() return "custom_val" end
+                }
+            }
+        }
+
+        local result = templater:process({ template = "Value: {{callme}}" })
+
+        assert.are.equal(
+            "Value: custom_val",
+            result,
+            "extra_providers from opts were not registered"
+        )
+    end)
+
+    it("does not call provider function if tag is not in template (lazy evaluation)", function()
+        local call_count = 0
+        local templater = Templater:new {
+            home = ".",
+            extra_providers = {
+                {
+                    name = "callme",
+                    func = function()
+                        call_count = call_count + 1
+                        return "input"
+                    end
+                }
+            }
+        }
+        -- case 1  not tag - not call 
+        local _ = templater:process({ template = "No tags here" })
+        assert.are.equal(0, call_count, "Provider function was called unexpectedly")
+
+        -- case 2  tag is - call is 
+        local result = templater:process({ template = "Tag: {{callme}}" })
+        assert.are.equal(1, call_count, "Provider function should be called exactly once")
+        assert.are.equal("Tag: input", result)
+    end)
+
+   it("calls provider only once for multiple occurrences of the same tag", function()
+    local call_count = 0
+    local templater = Templater:new {
+        home = ".",
+        extra_providers = {
+            {
+                name = "multi",
+                func = function() 
+                    call_count = call_count + 1
+                    return "val" 
+                end
+            }
+        }
+    }
+
+    local template = "{{multi}} {{multi}} {{multi}}"
+    local result = templater:process({ template = template })
+
+    assert.are.equal("val val val", result)
+    assert.are.equal(1, call_count, "Provider should be called exactly once for all occurrences")
+  end)
 end)


### PR DESCRIPTION
This MR introduces the ability to pass a custom list of VarProviders directly through the Templater configuration

Added extra_providers field to TemplaterOpts, allowing users to register custom variables during initialization

xample in Readme

Users can now create highly dynamic templates with on-the-fly input, while the system remains efficient by only triggering "resolvers" for tags that are actually in use.

---

PS: I did it fastly, I dont test it in all cases, we may will work in this, if its needed

Thanks for amazing plugin and good luck! 